### PR TITLE
feat: Allow to opt-out from publishing scaladocs

### DIFF
--- a/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/Publish.scala
@@ -230,8 +230,12 @@ object Publish extends ScalaCommand[PublishOptions] with BuildCommandHelpers {
     ).orExit(logger)
     val threads = BuildThreads.create()
 
-    val compilerMaker    = options.shared.compilerMaker(threads)
-    val docCompilerMaker = options.shared.compilerMaker(threads, scaladoc = true)
+    val compilerMaker = options.shared.compilerMaker(threads)
+    val docCompilerMaker =
+      Option.when(!options.publishParams.skipScaladocs)(options.shared.compilerMaker(
+        threads,
+        scaladoc = true
+      ))
 
     val cross = options.compileCross.cross.getOrElse(false)
 
@@ -278,7 +282,7 @@ object Publish extends ScalaCommand[PublishOptions] with BuildCommandHelpers {
     logger: Logger,
     initialBuildOptions: BuildOptions,
     compilerMaker: ScalaCompilerMaker,
-    docCompilerMaker: ScalaCompilerMaker,
+    docCompilerMaker: Option[ScalaCompilerMaker],
     cross: Boolean,
     workingDir: => os.Path,
     ivy2HomeOpt: Option[os.Path],
@@ -299,7 +303,7 @@ object Publish extends ScalaCommand[PublishOptions] with BuildCommandHelpers {
         inputs,
         initialBuildOptions,
         compilerMaker,
-        Some(docCompilerMaker),
+        docCompilerMaker,
         logger,
         crossBuilds = cross,
         buildTests = false,
@@ -333,7 +337,7 @@ object Publish extends ScalaCommand[PublishOptions] with BuildCommandHelpers {
           inputs,
           initialBuildOptions,
           compilerMaker,
-          Some(docCompilerMaker),
+          docCompilerMaker,
           logger,
           crossBuilds = cross,
           buildTests = false,

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/PublishLocal.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/PublishLocal.scala
@@ -51,8 +51,12 @@ object PublishLocal extends ScalaCommand[PublishLocalOptions] {
     ).orExit(logger)
     val threads = BuildThreads.create()
 
-    val compilerMaker    = options.shared.compilerMaker(threads)
-    val docCompilerMaker = options.shared.compilerMaker(threads, scaladoc = true)
+    val compilerMaker = options.shared.compilerMaker(threads)
+    val docCompilerMaker =
+      Option.when(!options.publishParams.skipScaladocs)(options.shared.compilerMaker(
+        threads,
+        scaladoc = true
+      ))
 
     val cross = options.compileCross.cross.getOrElse(false)
 

--- a/modules/cli/src/main/scala/scala/cli/commands/publish/PublishParamsOptions.scala
+++ b/modules/cli/src/main/scala/scala/cli/commands/publish/PublishParamsOptions.scala
@@ -73,8 +73,13 @@ final case class PublishParamsOptions(
   @HelpMessage("Use or setup publish parameters meant to be used on continuous integration")
   @Tag(tags.restricted)
   @Tag(tags.inShortHelp)
-    ci: Option[Boolean] = None
+    ci: Option[Boolean] = None,
 
+  @Group(HelpGroup.Publishing.toString)
+  @HelpMessage("Don't package scaladocs in the final artifact")
+  @Tag(tags.restricted)
+  @Tag(tags.inShortHelp)
+    skipScaladocs: Boolean = false
 ) {
   // format: on
 


### PR DESCRIPTION
This adds the ability to skip publishing (and compiling!) scaladocs.

**Justification**

At $work we use scala-cli a lot to publish locally artifacts. Some of them contains thousands of classes. We use scala-cli together with bloop to make the compilation fast. 

We noticed that there is a big overhead when running `publish local` compared to bare `compile`. After looking more into that, we also noticed that scala-cli created some huge directories (one had even 25 GB. Yes, there are over 25k files inside). That was `.scala-build/sources-xyz/classes/main-doc/`. 

For our use-case we actually don't care at all about scaladoc files, and would happily skip them to benefit from faster times of `publish local` command.

Publishing scaladocs is especially slow as it uses a simple compiler without going through bloop.